### PR TITLE
Make ReplayDecoder Public

### DIFF
--- a/Source/2_Core/Models/Replay.cs
+++ b/Source/2_Core/Models/Replay.cs
@@ -513,7 +513,7 @@ namespace BeatLeader.Models.Replay {
             stream.Write(quaternion.w);
         }
     }
-    static class ReplayDecoder
+    public static class ReplayDecoder
     {
         public static bool TryDecodeReplayInfo(byte[] buffer, out ReplayInfo? info) {
             try {


### PR DESCRIPTION
Replay Decoder is not currently public, so i am unable to use it in localleaderboard without reflection